### PR TITLE
Fix byte-compile warnings on newer Emacs

### DIFF
--- a/simplecov.el
+++ b/simplecov.el
@@ -105,9 +105,9 @@
        (-map #'1+)))
 
 (defun simplecov--lines->regions (lines)
-  "Take `LINES' data and return the regions '((beg . end)...) of those lines."
-  (--map (cons (point-at-bol it)
-               (point-at-eol it))
+  "Take `LINES' data and return the regions \\='((beg . end)...) of those lines."
+  (--map (cons (line-beginning-position it)
+               (line-end-position it))
          lines))
 
 (defun simplecov--regions->overlays (regions)


### PR DESCRIPTION
There are some warnings on development Emacs

```
In simplecov--lines->regions:
simplecov.el:107:2: Warning: docstring has wrong usage of unescaped single
    quotes (use \= or different quoting)
simplecov.el:109:17: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
simplecov.el:110:17: Warning: ‘point-at-eol’ is an obsolete function (as of
    29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
```